### PR TITLE
User can add a favorite song to the database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ coverage
 node_modules
 
 .env
+
+.jshintrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,4 @@ script:
 
 before_script:
   - psql -c 'create database play_test;' -U postgres
+  - knex migrate:latest --env test

--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ const environment = process.env.NODE_ENV || 'development';
 const configuration = require('./knexfile')[environment];
 
 var indexRouter = require('./routes/index');
+var favoritesRouter = require('./routes/api/v1/favorites');
 
 var app = express();
 
@@ -17,12 +18,8 @@ app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', indexRouter);
+app.use('/api/v1/favorites', favoritesRouter);
 
-app.set('port', process.env.PORT || 3000);
 app.locals.title = 'Play';
-
-app.listen(app.get('port'), () => {
-  console.log(`${app.locals.title} is running on ${app.get('port')}`)
-});
 
 module.exports = app;

--- a/db/migrations/20200203144754_favorites.js
+++ b/db/migrations/20200203144754_favorites.js
@@ -1,0 +1,19 @@
+
+exports.up = function(knex) {
+  return Promise.all([
+    knex.schema.createTable('favorites', function(table) {
+      table.increments('id').primary();
+      table.string('title');
+      table.string('artistName');
+      table.string('genre').defaultTo('Unknown');
+      table.integer('rating');
+      table.timestamps(true, true);
+    })
+  ]);
+};
+
+exports.down = function(knex) {
+  return Promise.all([
+    knex.schema.dropTable('favorites')
+  ]);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -3796,6 +3796,11 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "express": "~4.16.1",
     "knex": "^0.19.5",
     "morgan": "~1.9.1",
+    "node-fetch": "^2.6.0",
     "pg": "^7.8.0"
   },
   "devDependencies": {

--- a/pojos/track.js
+++ b/pojos/track.js
@@ -1,0 +1,20 @@
+class Track {
+
+  constructor(data) {
+    this.title = data.message.body.track_list[0].track.track_name;
+    this.artistName = data.message.body.track_list[0].track.artist_name;
+    this.rating = data.message.body.track_list[0].track.track_rating;
+    this.genre = this.getGenre(data.message.body.track_list[0].track.primary_genres.music_genre_list);
+  }
+
+  getGenre(data) {
+    if (data[0]) {
+      return data[0].music_genre.music_genre_name;
+    } else {
+      return 'Unknown';  
+    }
+  }
+
+}
+
+module.exports = Track;

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -1,0 +1,55 @@
+const dotenv = require('dotenv').config();
+var express = require('express');
+var router = express.Router();
+
+const Track = require('../../../pojos/track');
+
+const environment = process.env.NODE_ENV || 'development';
+const configuration = require('../../../knexfile')[environment];
+const database = require('knex')(configuration);
+const fetch = require('node-fetch');
+const { URL, URLSearchParams } = require('url');
+
+router.post('/', async (request, response) => {
+  if (request.body.title && request.body.artistName) {
+    let trackTitle = request.body.title;
+    let artistName = request.body.artistName;
+
+    let url = new URL('https://api.musixmatch.com/ws/1.1/track.search');
+    let params = {
+      apikey: process.env.MUSIXMATCH_API_KEY,
+      q_artist: artistName,
+      q_track: trackTitle,
+      s_artist_rating: 'desc'
+    };
+    url.search = new URLSearchParams(params).toString();
+
+    try {
+      let favoriteTrack = await fetch(url);
+      let trackData = await favoriteTrack.json();
+      let track = new Track(trackData);
+
+      let insertToDB = database('favorites').insert(
+        { title: track.title,
+          artistName: track.artistName,
+          genre: track.genre,
+          rating: track.rating
+        }, ['id', 'title', 'artistName', 'genre', 'rating'])
+        .then(track => response.status(200).json(track[0]));
+    } catch(error) {
+      console.log(error);
+      response.status(200).json({error: 'There was an error.'});
+    }
+
+  } else if (request.body.title && !request.body.artistName) {
+    response.status(400).json({error: 'Bad Request! Did you send an artist name?'});
+  } else if (!request.body.title && request.body.artistName) {
+    response.status(400).json({error: 'Bad Request! Did you send a song title?'});
+  } else {
+    response.status(400).json({error: 'Bad Request! Did you send an artist name and song title?'});
+  }
+
+});
+
+module.exports = router;
+

--- a/server.js
+++ b/server.js
@@ -1,0 +1,8 @@
+const app = require('./app.js')
+
+
+//This is the code that is removed from index.js or app.js
+app.set('port', process.env.PORT || 3000);
+app.listen(app.get('port'), () => {
+  console.log(`${app.locals.title} is running on http://localhost:${app.get('port')}`);
+});

--- a/tests/add-favorite.spec.js
+++ b/tests/add-favorite.spec.js
@@ -3,7 +3,7 @@ var request = require("supertest");
 var app = require('../app');
 
 describe('Add favorites endpoint', () => {
-  test('It can add a new favorite song', async () => {
+  test('It can add a new favorite track', async () => {
     const res = await request(app)
       .post("/api/v1/favorites")
       .send({ title: "We Will Rock You", artistName: "Queen" })
@@ -16,10 +16,66 @@ describe('Add favorites endpoint', () => {
     expect(res.body).toHaveProperty('artistName');
     expect(res.body).toHaveProperty('genre');
     expect(res.body).toHaveProperty('rating');
-    
+
     expect(res.body.title).toEqual('We Will Rock You');
     expect(res.body.artistName).toEqual('Queen');
     expect(res.body.genre).toEqual('Rock');
+    expect(res.body.rating).toBeGreaterThanOrEqual(1);
+    expect(res.body.rating).toBeLessThanOrEqual(100);
+  });
+
+  test('It cannot add a new favorite track if missing the artist name', async () => {
+    const res = await request(app)
+
+    .post("/api/v1/favorites")
+    .send({ title: "We Will Rock You" })
+    .type('form');
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toHaveProperty('error');
+    expect(res.body.error).toEqual('Bad Request! Did you send an artist name?');
+  });
+
+  test('It cannot add a new favorite track if missing the track title', async () => {
+    const res = await request(app)
+
+    .post("/api/v1/favorites")
+    .send({ artistName: "Queen" })
+    .type('form');
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toHaveProperty('error');
+    expect(res.body.error).toEqual('Bad Request! Did you send a song title?');
+  });
+
+  test('It cannot add a new favorite track if missing the track title and artist name', async () => {
+    const res = await request(app)
+
+    .post("/api/v1/favorites")
+    .send({})
+    .type('form');
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toHaveProperty('error');
+    expect(res.body.error).toEqual('Bad Request! Did you send an artist name and song title?');
+  });
+
+  test('It adds the track if the genre is unknown', async () => {
+    const res = await request(app)
+
+    .post("/api/v1/favorites")
+    .send({ title: "We Will Rock You", artistName: "Queen, Anastacia, Amampondo Drummers" })
+    .type('form');
+
+    expect(res.body).toHaveProperty('id');
+    expect(res.body).toHaveProperty('title');
+    expect(res.body).toHaveProperty('artistName');
+    expect(res.body).toHaveProperty('genre');
+    expect(res.body).toHaveProperty('rating');
+
+    expect(res.body.title).toEqual('We Will Rock You');
+    expect(res.body.artistName).toEqual('Queen, Anastacia, Amampondo Drummers');
+    expect(res.body.genre).toEqual('Unknown');
     expect(res.body.rating).toBeGreaterThanOrEqual(1);
     expect(res.body.rating).toBeLessThanOrEqual(100);
   });

--- a/tests/add-favorite.spec.js
+++ b/tests/add-favorite.spec.js
@@ -1,0 +1,26 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../app');
+
+describe('Add favorites endpoint', () => {
+  test('It can add a new favorite song', async () => {
+    const res = await request(app)
+      .post("/api/v1/favorites")
+      .send({ title: "We Will Rock You", artistName: "Queen" })
+      .type('form');
+
+    expect(res.statusCode).toBe(200);
+
+    expect(res.body).toHaveProperty('id');
+    expect(res.body).toHaveProperty('title');
+    expect(res.body).toHaveProperty('artistName');
+    expect(res.body).toHaveProperty('genre');
+    expect(res.body).toHaveProperty('rating');
+    
+    expect(res.body.title).toEqual('We Will Rock You');
+    expect(res.body.artistName).toEqual('Queen');
+    expect(res.body.genre).toEqual('Rock');
+    expect(res.body.rating).toBeGreaterThanOrEqual(1);
+    expect(res.body.rating).toBeLessThanOrEqual(100);
+  });
+});


### PR DESCRIPTION
- Make a table for Favorite tracks
- Add favorites route and router files for the `api/v1/favorites` endpoint
- Add server.js file to launch the app to avoid port conflict
- Add Track POJO to hold track info
- Write test for happy and common sad paths

- Test coverage is 93.33%