### PR TITLE
User can see a list of their favorite songs

### DIFF
--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -51,5 +51,12 @@ router.post('/', async (request, response) => {
 
 });
 
+router.get('/', async (request, response) => {
+  database('favorites')
+      .then((favorites) => {
+        response.status(200).json(favorites);
+      });
+});
+
 module.exports = router;
 

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -54,8 +54,12 @@ router.post('/', async (request, response) => {
 router.get('/', async (request, response) => {
   database('favorites')
       .then((favorites) => {
-        response.status(200).json(favorites);
-      });
+        if (favorites.length) {
+          response.status(200).json(favorites);
+        } else {
+          response.status(200).json({ message: 'No favorites found!' });
+        }
+      }).catch(error => response.status(404).json({error: "There was an error!"}));
 });
 
 module.exports = router;

--- a/tests/add-favorite.spec.js
+++ b/tests/add-favorite.spec.js
@@ -2,7 +2,15 @@ var shell = require('shelljs');
 var request = require("supertest");
 var app = require('../app');
 
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../knexfile')[environment];
+const database = require('knex')(configuration);
+
 describe('Add favorites endpoint', () => {
+  beforeEach(async () => {
+       await database.raw('truncate table favorites cascade');
+    });
+
   test('It can add a new favorite track', async () => {
     const res = await request(app)
       .post("/api/v1/favorites")

--- a/tests/add-favorite.spec.js
+++ b/tests/add-favorite.spec.js
@@ -11,6 +11,10 @@ describe('Add favorites endpoint', () => {
        await database.raw('truncate table favorites cascade');
     });
 
+    afterEach(() => {
+      database.raw('truncate table favorites cascade');
+    });
+
   test('It can add a new favorite track', async () => {
     const res = await request(app)
       .post("/api/v1/favorites")

--- a/tests/view-favorites.spec.js
+++ b/tests/view-favorites.spec.js
@@ -44,8 +44,6 @@ describe('Test the favorites path', () => {
   test('It should send back all of a users favorites', async () => {
     const res = await request(app)
     .get("/api/v1/favorites")
-    .send({ title: "We Will Rock You", artistName: "Queen" })
-    .type('form');
 
     expect(res.statusCode).toBe(200);
 
@@ -67,10 +65,10 @@ describe('Test the favorites path', () => {
     expect(res.body[1].rating).toBeGreaterThanOrEqual(1);
     expect(res.body[1].rating).toBeLessThanOrEqual(100);
 
-    expect(res.body[1].title).toEqual('Changes');
-    expect(res.body[1].artistName).toEqual('2Pac');
-    expect(res.body[1].genre).toEqual('Hip Hop/Rap');
-    expect(res.body[1].rating).toBeGreaterThanOrEqual(1);
-    expect(res.body[1].rating).toBeLessThanOrEqual(100);
+    expect(res.body[2].title).toEqual('Changes');
+    expect(res.body[2].artistName).toEqual('2Pac');
+    expect(res.body[2].genre).toEqual('Hip Hop/Rap');
+    expect(res.body[2].rating).toBeGreaterThanOrEqual(1);
+    expect(res.body[2].rating).toBeLessThanOrEqual(100);
   });
 });

--- a/tests/view-favorites.spec.js
+++ b/tests/view-favorites.spec.js
@@ -15,7 +15,7 @@ describe('Test the favorites path', () => {
     database.raw('truncate table favorites cascade');
   });
 
-  test('It should send back all of a users favorites', async () => {
+  test('It should send back all of a users favorite tracks', async () => {
 
       let favorite1 = {
         title: "We Will Rock You",

--- a/tests/view-favorites.spec.js
+++ b/tests/view-favorites.spec.js
@@ -7,34 +7,8 @@ const configuration = require('../knexfile')[environment];
 const database = require('knex')(configuration);
 
 describe('Test the favorites path', () => {
-
   beforeEach(async () => {
     await database.raw('truncate table favorites cascade');
-
-    let favorite1 = {
-      title: "We Will Rock You",
-      artistName: "Queen",
-      genre: "Rock",
-      rating: 87
-    };
-
-    let favorite2 = {
-      title: "Shake It Off",
-      artistName: "Taylor Swift",
-      genre: "Pop",
-      rating: 84
-    };
-
-    let favorite3 = {
-     title: "Changes",
-     artistName: "2Pac",
-     genre: "Hip Hop/Rap",
-     rating: 50
-    };
-
-    await database('favorites').insert(favorite1, 'id');
-    await database('favorites').insert(favorite2, 'id');
-    await database('favorites').insert(favorite3, 'id');
   });
 
   afterEach(() => {
@@ -42,8 +16,34 @@ describe('Test the favorites path', () => {
   });
 
   test('It should send back all of a users favorites', async () => {
+
+      let favorite1 = {
+        title: "We Will Rock You",
+        artistName: "Queen",
+        genre: "Rock",
+        rating: 87
+      };
+
+      let favorite2 = {
+        title: "Shake It Off",
+        artistName: "Taylor Swift",
+        genre: "Pop",
+        rating: 84
+      };
+
+      let favorite3 = {
+       title: "Changes",
+       artistName: "2Pac",
+       genre: "Hip Hop/Rap",
+       rating: 50
+      };
+
+      await database('favorites').insert(favorite1, 'id');
+      await database('favorites').insert(favorite2, 'id');
+      await database('favorites').insert(favorite3, 'id');
+
     const res = await request(app)
-    .get("/api/v1/favorites")
+    .get("/api/v1/favorites");
 
     expect(res.statusCode).toBe(200);
 

--- a/tests/view-favorites.spec.js
+++ b/tests/view-favorites.spec.js
@@ -1,0 +1,76 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../knexfile')[environment];
+const database = require('knex')(configuration);
+
+describe('Test the favorites path', () => {
+
+  beforeEach(async () => {
+    await database.raw('truncate table favorites cascade');
+
+    let favorite1 = {
+      title: "We Will Rock You",
+      artistName: "Queen",
+      genre: "Rock",
+      rating: 87
+    };
+
+    let favorite2 = {
+      title: "Shake It Off",
+      artistName: "Taylor Swift",
+      genre: "Pop",
+      rating: 84
+    };
+
+    let favorite3 = {
+     title: "Changes",
+     artistName: "2Pac",
+     genre: "Hip Hop/Rap",
+     rating: 50
+    };
+
+    await database('favorites').insert(favorite1, 'id');
+    await database('favorites').insert(favorite2, 'id');
+    await database('favorites').insert(favorite3, 'id');
+  });
+
+  afterEach(() => {
+    database.raw('truncate table favorites cascade');
+  });
+
+  test('It should send back all of a users favorites', async () => {
+    const res = await request(app)
+    .get("/api/v1/favorites")
+    .send({ title: "We Will Rock You", artistName: "Queen" })
+    .type('form');
+
+    expect(res.statusCode).toBe(200);
+
+    expect(res.body[0]).toHaveProperty('id');
+    expect(res.body[0]).toHaveProperty('title');
+    expect(res.body[0]).toHaveProperty('artistName');
+    expect(res.body[0]).toHaveProperty('genre');
+    expect(res.body[0]).toHaveProperty('rating');
+
+    expect(res.body[0].title).toEqual('We Will Rock You');
+    expect(res.body[0].artistName).toEqual('Queen');
+    expect(res.body[0].genre).toEqual('Rock');
+    expect(res.body[0].rating).toBeGreaterThanOrEqual(1);
+    expect(res.body[0].rating).toBeLessThanOrEqual(100);
+
+    expect(res.body[1].title).toEqual('Shake It Off');
+    expect(res.body[1].artistName).toEqual('Taylor Swift');
+    expect(res.body[1].genre).toEqual('Pop');
+    expect(res.body[1].rating).toBeGreaterThanOrEqual(1);
+    expect(res.body[1].rating).toBeLessThanOrEqual(100);
+
+    expect(res.body[1].title).toEqual('Changes');
+    expect(res.body[1].artistName).toEqual('2Pac');
+    expect(res.body[1].genre).toEqual('Hip Hop/Rap');
+    expect(res.body[1].rating).toBeGreaterThanOrEqual(1);
+    expect(res.body[1].rating).toBeLessThanOrEqual(100);
+  });
+});

--- a/tests/view-favorites.spec.js
+++ b/tests/view-favorites.spec.js
@@ -71,4 +71,14 @@ describe('Test the favorites path', () => {
     expect(res.body[2].rating).toBeGreaterThanOrEqual(1);
     expect(res.body[2].rating).toBeLessThanOrEqual(100);
   });
+
+  test('It should send back a message saying there were no favorites found if there are no favorites', async () => {
+    const res = await request(app)
+      .get("/api/v1/favorites");
+
+    expect(res.statusCode).toBe(200);
+
+    expect(res.body).toHaveProperty('message');
+    expect(res.body.message).toEqual("No favorites found!");
+  });
 });


### PR DESCRIPTION
Features of PR:
- Add testing database cleaners in a `beforeEach` and `afterEach` block to all test files that modify the database. Verified that it is working in Postico.
- Add test to check that a user can get a list of all favorite tracks back when they send a `GET` request to `api/v1/favorites`
- Add a endpoint for GET request to `api/v1/favorites` that returns the list of favorites as JSON

Testing:
- Test coverage 91.67%.

Refactors / Thoughts:
- We need to try and figure out how to test the `.catch` blocks because those are the lines we are not hitting in our testing coverage