### PR TITLE
User can see a single favorite song when requested by id / Update GET favorites response to send back empty array

### DIFF
--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -38,13 +38,8 @@ router.post('/', async (request, response) => {
 
 router.get('/', async (request, response) => {
   return await database('favorites').select()
-      .then((favorites) => {
-        if (favorites.length) {
-          return response.status(200).json(favorites);
-        } else {
-          response.status(200).json(favorites);
-        }
-      }).catch(error => response.status(500).json({error: "There was an error!"}));
+      .then((favorites) => response.status(200).json(favorites))
+      .catch(error => response.status(500).json({error: "There was an error!"}));
 });
 
 router.get('/:id', async (request, response) => {

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -52,14 +52,25 @@ router.post('/', async (request, response) => {
 });
 
 router.get('/', async (request, response) => {
-  database('favorites')
+  database('favorites').select()
       .then((favorites) => {
         if (favorites.length) {
           response.status(200).json(favorites);
         } else {
-          response.status(200).json({ message: 'No favorites found!' });
+          response.status(200).json(favorites);
         }
-      }).catch(error => response.status(404).json({error: "There was an error!"}));
+      }).catch(error => response.status(500).json({error: "There was an error!"}));
+});
+
+router.get('/:id', async (request, response) => {
+  database('favorites').where('id', request.params.id).select()
+      .then((favorite) => {
+        if (favorite.length) {
+          response.status(200).json(favorite[0]);
+        } else {
+          response.status(404).json({error: "No favorite track was found with that id"});
+        }
+      }).catch(error => response.status(500).json({error: "There was an error!"}));
 });
 
 module.exports = router;

--- a/tests/view-favorite-by-id.spec.js
+++ b/tests/view-favorite-by-id.spec.js
@@ -1,0 +1,70 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../knexfile')[environment];
+const database = require('knex')(configuration);
+
+describe('Test the favorites path', () => {
+  beforeEach(async () => {
+    await database.raw('truncate table favorites cascade');
+  });
+
+  afterEach(() => {
+    database.raw('truncate table favorites cascade');
+  });
+
+  test('It should respond to a GET request for a favorite :id with that favorite' , async () => {
+
+    let favorite1 = {
+     title: "Under Pressure",
+     artistName: "David Bowie w/ Queen",
+     genre: "Rock & Roll",
+     rating: 36
+    };
+
+    let favorite2 = {
+     title: "Can I Kick It?",
+     artistName: "A Tribe Called Quest",
+     genre: "Pop",
+     rating: 33
+    };
+
+    let favorite1_id = await database('favorites').insert(favorite1, 'id');
+    let favorite2_id =  await database('favorites').insert(favorite2, 'id');
+
+    const res = await request(app)
+      .get(`/api/v1/favorites/${favorite1_id}`);
+
+    console.log(res.body);
+    expect(res.statusCode).toBe(200);
+
+    expect(res.body).toHaveProperty('id');
+    expect(res.body).toHaveProperty('title');
+    expect(res.body).toHaveProperty('artistName');
+    expect(res.body).toHaveProperty('genre');
+    expect(res.body).toHaveProperty('rating');
+
+    expect(res.body.title).toEqual('Under Pressure');
+    expect(res.body.artistName).toEqual('David Bowie w/ Queen');
+    expect(res.body.genre).toEqual('Rock & Roll');
+    expect(res.body.rating).toBeGreaterThanOrEqual(1);
+    expect(res.body.rating).toBeLessThanOrEqual(100);
+
+    expect(res.body.title).not.toEqual('Can I Kick It?');
+    expect(res.body.artistName).not.toEqual('A Tribe Called Quest');
+    expect(res.body.genre).not.toEqual('Pop');
+  });
+
+  test('It should respond to a GET request for a favorite :id with a message if that favorite cant be found' , async () => {
+    const res = await request(app)
+      .get(`/api/v1/favorites/10000000`);
+
+      expect(res.statusCode).toBe(404);
+
+      expect(res.body).toHaveProperty('error');
+      expect(res.body.error).toEqual("No favorite track was found with that id");
+  });
+
+});

--- a/tests/view-favorites.spec.js
+++ b/tests/view-favorites.spec.js
@@ -72,13 +72,12 @@ describe('Test the favorites path', () => {
     expect(res.body[2].rating).toBeLessThanOrEqual(100);
   });
 
-  test('It should send back a message saying there were no favorites found if there are no favorites', async () => {
+  test('It should send back an the empty array if there are no favorites', async () => {
     const res = await request(app)
       .get("/api/v1/favorites");
 
     expect(res.statusCode).toBe(200);
 
-    expect(res.body).toHaveProperty('message');
-    expect(res.body.message).toEqual("No favorites found!");
+    expect(res.body).toEqual([]);
   });
 });


### PR DESCRIPTION
Features of PR:
- Add a endpoint for GET request to `api/v1/favorites/:id` that returns the favorite as JSON.
- Update the `api/v1/favorites` endpoint to return an empty array when no collection of favorites is found.
- Update `api/v1/favorites` endpoint .catch to return 500 errors instead of 404 errors.

Testing:
- Test coverage 90.48%.

Refactors / Thoughts
- The lines that aren't being hit are still the `.catch` blocks.