### PR TITLE
A user can delete a favorite song from the database

### DIFF
--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -62,5 +62,18 @@ router.get('/', async (request, response) => {
       }).catch(error => response.status(404).json({error: "There was an error!"}));
 });
 
-module.exports = router;
+router.delete('/:id', async (request, response) => {
+  database('favorites')
+    .where('id', request.params.id)
+    .del()
+    .then(rows => {
+      if (rows === 1) {
+        return response.status(204).send();
+      } else {
+        return response.status(404).json({error: 'No favorite track with that ID was found. Please try again.'});
+      }
+    })
+    .catch(error => response.status(500).json({error: 'There was an error!'}));
+});
 
+module.exports = router;

--- a/tests/delete-favorite.spec.js
+++ b/tests/delete-favorite.spec.js
@@ -1,0 +1,58 @@
+var shell = require('shelljs');
+var request = require('supertest');
+var app = require('../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../knexfile')[environment];
+const database = require('knex')(configuration);
+
+describe('Delete favorites endpoint', () => {
+  beforeEach(async () => {
+       await database.raw('truncate table favorites cascade');
+    });
+
+  afterEach(async () => {
+    await database.raw('truncate table favorites cascade');
+  });
+
+  test('It can delete a favorite track by id', async () => {
+    let favorite1 = {
+      title: 'Taylor',
+      artistName: 'Jack Johnson',
+      genre: 'Rock',
+      rating: 26
+    };
+
+    let favorite2 = {
+      title: 'Shake It Off',
+      artistName: 'Taylor Swift',
+      genre: 'Pop',
+      rating: 84
+    };
+
+    let favorite_ids = await database('favorites').insert([favorite1, favorite2], 'id')
+
+    const delete_res = await request(app)
+      .delete(`/api/v1/favorites/${favorite_ids[0]}`);
+
+    expect(delete_res.statusCode).toBe(204)
+
+    const list_res = await request(app)
+      .get("/api/v1/favorites");
+
+    expect(list_res.statusCode).toBe(200);
+    expect(list_res.body.length).toBe(1);
+
+    expect(list_res.body[0]).toHaveProperty('id');
+    expect(list_res.body[0].id).toBe(favorite_ids[1]);
+  });
+
+  test('It sends a 404 message that no track was found if id is invalid', async () => {
+    const res = await request(app)
+      .delete('/api/v1/favorites/4');
+
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toHaveProperty('error');
+    expect(res.body.error).toBe('No favorite track with that ID was found. Please try again.')
+  });
+});


### PR DESCRIPTION
- Add router delete method to delete a favorite track by id
- Add test that `DELETE /api/v1/favorites/:id` returns a 204 response and deletes the track from the favorites table
- Add test that 404 response is returned if no favorite is found with given ID

- Test coverage is 90.48%