### PR TITLE
18 refactor get favorite by id

### DIFF
--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -58,7 +58,14 @@ router.get('/:id', async (request, response) => {
   let favorite =  await database('favorites').where('id', request.params.id);
 
   if (favorite.length) {
-    return response.status(200).json(favorite[0]);
+    favoriteTrack = {
+      id: favorite[0].id,
+      title: favorite[0].title,
+      artistName: favorite[0].artistName,
+      genre: favorite[0].genre,
+      rating: favorite[0].rating
+    };
+    return response.status(200).json(favoriteTrack);
   } else {
     let res_obj = new ResponseObj(404, 'No favorite track with given ID was found. Please check the ID and try again.');
     return errorResponse(res_obj, response);

--- a/tests/view-favorite-by-id.spec.js
+++ b/tests/view-favorite-by-id.spec.js
@@ -45,6 +45,9 @@ describe('Test the favorites path', () => {
     expect(res.body).toHaveProperty('genre');
     expect(res.body).toHaveProperty('rating');
 
+    expect(res.body).not.toHaveProperty('created_at');
+    expect(res.body).not.toHaveProperty('updated_at');
+
     expect(res.body.title).toEqual('Under Pressure');
     expect(res.body.artistName).toEqual('David Bowie w/ Queen');
     expect(res.body.genre).toEqual('Rock & Roll');


### PR DESCRIPTION
Features of PR:
- Add test that a request to the `/api/v`/favorites/:id` endpoint does not return a created_at or updated_at date
- Update the favorites `/:id` router to return an object literal that doesn't include the created_at and updated_at 

Testing:
- Test coverage is 93.44%

Refactors / Thoughts:
- none
