### PR TITLE
Add endpoint for a POST request to `/api/v1/playlists`

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ const configuration = require('./knexfile')[environment];
 
 var indexRouter = require('./routes/index');
 var favoritesRouter = require('./routes/api/v1/favorites');
+var playlistsRouter = require('./routes/api/v1/playlists');
 
 var app = express();
 
@@ -19,6 +20,7 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', indexRouter);
 app.use('/api/v1/favorites', favoritesRouter);
+app.use('/api/v1/playlists', playlistsRouter);
 
 app.locals.title = 'Play';
 

--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -1,0 +1,62 @@
+const dotenv = require('dotenv').config();
+const express = require('express');
+const router = express.Router();
+
+const ResponseObj = require('../../../pojos/responseObj');
+
+const environment = process.env.NODE_ENV || 'development';
+const configuration = require('../../../knexfile')[environment];
+const database = require('knex')(configuration);
+
+router.post('/', async (request, response) => {
+  let playlistTitle = request.body.title;
+
+  if (playlistTitle) {
+
+    let playlist = { title: playlistTitle };
+    let existsResObj = await alreadyFavorite(playlist);
+    if (existsResObj.status === 409) { return errorResponse(existsResObj, response); }
+
+    let savedPlaylistResObj = await addPlaylistToDB(playlist);
+    if (savedPlaylistResObj.status === 201) {
+      return response.status(201).json(savedPlaylistResObj.payload);
+    } else {
+      return errorResponse(savedPlaylistResObj, response);
+    }
+  } else {
+    let res_obj = new ResponseObj(400, 'Bad Request! Did you send a playlist title?');
+    return errorResponse(res_obj, response);
+  }
+});
+
+async function alreadyFavorite(playlist) {
+  let playlists = await database('playlists')
+    .where({'title': playlist.title});
+  if (playlists.length) {
+    return new ResponseObj(409, 'A playlist with that title has already been added to your playlists!');
+  } else {
+    return new ResponseObj(200, 'Playlist has not yet been favorited.');
+  }
+};
+
+async function addPlaylistToDB(playlist) {
+  let savedPlaylist = await database('playlists').insert(
+      {
+        title: playlist.title,
+      }, ['id', 'title', 'created_at', 'updated_at']);
+
+  if (savedPlaylist[0]) {
+    return new ResponseObj(201, savedPlaylist[0]);
+  } else {
+    return new ResponseObj(500, 'New playlist cannot be saved into database. Please try again.');
+  }
+};
+
+function errorResponse(resObj, response) {
+  return response.status(resObj.status).json({
+    status: resObj.status,
+    errorMessage: resObj.payload
+  });
+};
+
+module.exports = router;

--- a/tests/favorites/add-favorite.spec.js
+++ b/tests/favorites/add-favorite.spec.js
@@ -1,18 +1,18 @@
 var shell = require('shelljs');
 var request = require("supertest");
-var app = require('../app');
+var app = require('../../app');
 
 const environment = process.env.NODE_ENV || 'test';
-const configuration = require('../knexfile')[environment];
+const configuration = require('../../knexfile')[environment];
 const database = require('knex')(configuration);
 
 describe('Add favorites endpoint', () => {
   beforeEach(async () => {
-    await database.raw('truncate table favorites cascade');
+    await database.raw('TRUNCATE TABLE favorites RESTART IDENTITY CASCADE');
   });
 
   afterEach(async () => {
-    await database.raw('truncate table favorites cascade');
+    await database.raw('TRUNCATE TABLE favorites RESTART IDENTITY CASCADE');
   });
 
   test('It can add a new favorite track', async () => {
@@ -29,6 +29,7 @@ describe('Add favorites endpoint', () => {
     expect(res.body).toHaveProperty('genre');
     expect(res.body).toHaveProperty('rating');
 
+    expect(res.body.id).toEqual(1); // TEST THAT THE TABLE IS BEING TRUNCATED
     expect(res.body.title).toEqual('We Will Rock You');
     expect(res.body.artistName).toEqual('Queen');
     expect(res.body.genre).toEqual('Rock');

--- a/tests/favorites/delete-favorite.spec.js
+++ b/tests/favorites/delete-favorite.spec.js
@@ -1,18 +1,18 @@
 var shell = require('shelljs');
 var request = require('supertest');
-var app = require('../app');
+var app = require('../../app');
 
 const environment = process.env.NODE_ENV || 'test';
-const configuration = require('../knexfile')[environment];
+const configuration = require('../../knexfile')[environment];
 const database = require('knex')(configuration);
 
 describe('Delete favorites endpoint', () => {
   beforeEach(async () => {
-       await database.raw('truncate table favorites cascade');
+       await database.raw('TRUNCATE TABLE favorites RESTART IDENTITY CASCADE');
     });
 
   afterEach(async () => {
-    await database.raw('truncate table favorites cascade');
+    await database.raw('TRUNCATE TABLE favorites RESTART IDENTITY CASCADE');
   });
 
   test('It can delete a favorite track by id', async () => {

--- a/tests/favorites/view-favorite-by-id.spec.js
+++ b/tests/favorites/view-favorite-by-id.spec.js
@@ -1,18 +1,18 @@
 var shell = require('shelljs');
 var request = require("supertest");
-var app = require('../app');
+var app = require('../../app');
 
 const environment = process.env.NODE_ENV || 'test';
-const configuration = require('../knexfile')[environment];
+const configuration = require('../../knexfile')[environment];
 const database = require('knex')(configuration);
 
 describe('Test the favorites path', () => {
   beforeEach(async () => {
-    await database.raw('truncate table favorites cascade');
+    await database.raw('TRUNCATE TABLE favorites RESTART IDENTITY CASCADE');
   });
 
-  afterEach(() => {
-    database.raw('truncate table favorites cascade');
+  afterEach(async () => {
+    await database.raw('TRUNCATE TABLE favorites RESTART IDENTITY CASCADE');
   });
 
   test('It should respond to a GET request for a favorite :id with that favorite' , async () => {

--- a/tests/favorites/view-favorites.spec.js
+++ b/tests/favorites/view-favorites.spec.js
@@ -1,18 +1,18 @@
 var shell = require('shelljs');
 var request = require("supertest");
-var app = require('../app');
+var app = require('../../app');
 
 const environment = process.env.NODE_ENV || 'test';
-const configuration = require('../knexfile')[environment];
+const configuration = require('../../knexfile')[environment];
 const database = require('knex')(configuration);
 
 describe('Test the favorites path', () => {
   beforeEach(async () => {
-    await database.raw('truncate table favorites cascade');
+    await database.raw('TRUNCATE TABLE favorites RESTART IDENTITY CASCADE');
   });
 
   afterEach(async () => {
-    await database.raw('truncate table favorites cascade');
+    await database.raw('TRUNCATE TABLE favorites RESTART IDENTITY CASCADE');
   });
 
   test('It should send back all of a users favorite tracks', async () => {

--- a/tests/playlists/add-playlist.spec.js
+++ b/tests/playlists/add-playlist.spec.js
@@ -34,7 +34,7 @@ describe('Add playlists endpoint', () => {
     // expect(res.body.rating).toBeLessThanOrEqual(100);
   });
 
-  test('It cannot add a new playlist track if missing the title', async () => {
+  test('It cannot add a new playlist if missing the title', async () => {
     const res = await request(app)
       .post("/api/v1/playlists")
       .send({ title: "" })

--- a/tests/playlists/add-playlist.spec.js
+++ b/tests/playlists/add-playlist.spec.js
@@ -1,0 +1,66 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../../knexfile')[environment];
+const database = require('knex')(configuration);
+
+describe('Add playlists endpoint', () => {
+  beforeEach(async () => {
+    await database.raw('TRUNCATE TABLE playlists RESTART IDENTITY CASCADE');
+  });
+
+  afterEach(async () => {
+    await database.raw('TRUNCATE TABLE playlists RESTART IDENTITY CASCADE');
+  });
+
+  test('It can add a new playlist', async () => {
+    const res = await request(app)
+      .post("/api/v1/playlists")
+      .send({ title: "Music For Cooking Pasta" })
+      .type('form');
+
+    expect(res.statusCode).toBe(201);
+
+    expect(res.body).toHaveProperty('id');
+    expect(res.body).toHaveProperty('title');
+    expect(res.body).toHaveProperty('created_at');
+    expect(res.body).toHaveProperty('updated_at');
+
+    // expect(res.body.id).toEqual(1); // TEST THAT THE TABLE IS BEING TRUNCATED
+    expect(res.body.title).toEqual('Music For Cooking Pasta');
+    // expect(res.body.rating).toBeGreaterThanOrEqual(1); HOW DO WE CHECK FOR CREATE AT?
+    // expect(res.body.rating).toBeLessThanOrEqual(100);
+  });
+
+  test('It cannot add a new playlist track if missing the title', async () => {
+    const res = await request(app)
+      .post("/api/v1/playlists")
+      .send({ title: "" })
+      .type('form');
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toHaveProperty('status');
+    expect(res.body).toHaveProperty('errorMessage');
+    expect(res.body.status).toEqual(400);
+    expect(res.body.errorMessage).toEqual('Bad Request! Did you send a playlist title?');
+  });
+
+  test('It cannot add the same playlist twice', async () => {
+    await database('playlists').insert({
+      title: 'CodeSongs',
+    })
+
+    const res = await request(app)
+      .post("/api/v1/playlists")
+      .send({ title: "CodeSongs" })
+      .type('form');
+
+    expect(res.statusCode).toBe(409);
+    expect(res.body).toHaveProperty('status');
+    expect(res.body).toHaveProperty('errorMessage');
+    expect(res.body.status).toBe(409);
+    expect(res.body.errorMessage).toBe('A playlist with that title has already been added to your playlists!');
+  });
+});

--- a/tests/playlists/add-playlist.spec.js
+++ b/tests/playlists/add-playlist.spec.js
@@ -28,10 +28,8 @@ describe('Add playlists endpoint', () => {
     expect(res.body).toHaveProperty('created_at');
     expect(res.body).toHaveProperty('updated_at');
 
-    // expect(res.body.id).toEqual(1); // TEST THAT THE TABLE IS BEING TRUNCATED
+    expect(res.body.id).toEqual(1); // TEST THAT THE TABLE IS BEING TRUNCATED
     expect(res.body.title).toEqual('Music For Cooking Pasta');
-    // expect(res.body.rating).toBeGreaterThanOrEqual(1); HOW DO WE CHECK FOR CREATE AT?
-    // expect(res.body.rating).toBeLessThanOrEqual(100);
   });
 
   test('It cannot add a new playlist if missing the title', async () => {

--- a/tests/playlists/add-playlist.spec.js
+++ b/tests/playlists/add-playlist.spec.js
@@ -48,7 +48,7 @@ describe('Add playlists endpoint', () => {
   test('It cannot add the same playlist twice', async () => {
     await database('playlists').insert({
       title: 'CodeSongs',
-    })
+    });
 
     const res = await request(app)
       .post("/api/v1/playlists")


### PR DESCRIPTION
Features of PR:
- Move favorties tests into a `/test/favorites` subdirectory.
- Make `/test/playlists` subdirectory.
- Add tests for a `POST` request to `/api/v1/playlists`.
- Add playlists route and router to `app.js`.
- Add endpoint for `POST` requests to `/api/v1/playlists` that adds a playlist to the playlists table.

Testing:
- Test coverage is 93.33%

Refactors / Thoughts:
- How do we check for created_at and updated_at?