### PR TITLE
User can get a list of playlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,27 @@ The response will be a status `204` with no response body.
 
 #### 1) Getting a list of all playlists
 
-#### 2) Updating a playlist
+When a user sends a `GET` request to `api/v1/playlists` it returns all playlists currently in the database.
+
+Response body will look like:
+```
+[
+ {
+    "id": 1,
+    "title": "Cleaning House",
+    "createdAt": 2019-11-26T16:03:43+00:00,
+    "updatedAt": 2019-11-26T16:03:43+00:00
+  },
+  {
+    "id": 2,
+    "title": "Running Mix",
+    "createdAt": 2019-11-26T16:03:43+00:00,
+    "updatedAt": 2019-11-26T16:03:43+00:00
+  },
+]
+```
+
+#### 2) Updating a playlist by id
 
 #### 3) Adding a playlist
 

--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -29,6 +29,24 @@ router.post('/', async (request, response) => {
   }
 });
 
+router.get('/', async (request, response) => {
+  let playlists = await database('playlists').select();
+
+  if (playlists) {
+    let playlistsArray = playlists.map(playlist => {
+      return {
+        id: playlist.id,
+        title: playlist.title,
+        createdAt: playlist.created_at,
+        updatedAt: playlist.updated_at
+      };
+    })
+    return response.status(200).json(playlistsArray);
+  } else {
+    let resp_obj = new ResponseObj(500, 'Unexpected error. Please try again.');
+    return errorResponse(res_obj, response);
+  }
+});
 router.delete('/:id', async (request, response) => {
   let rowsDeleted = await database('playlists').where('id', request.params.id).del();
 

--- a/tests/playlists/view-playlists.spec.js
+++ b/tests/playlists/view-playlists.spec.js
@@ -1,0 +1,59 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../../knexfile')[environment];
+const database = require('knex')(configuration);
+
+describe('Test get all playlists endpoint', () => {
+  beforeEach(async () => {
+    await database.raw('truncate table playlists restart identity cascade');
+  });
+
+  afterEach(async () => {
+    await database.raw('truncate table playlists restart identity cascade');
+  });
+
+  test('It should send back all of a users playlists', async () => {
+    let playlists = await database('playlists').insert([
+      { title: 'Road Trip!' },
+      { title: 'Love Mix Tape #341' },
+      { title: 'All of the Yogas' }
+    ], ['id', 'created_at', 'updated_at']);
+
+    const res = await request(app)
+      .get('/api/v1/playlists');
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.length).toBe(3);
+
+    expect(res.body[0]).toHaveProperty('id');
+    expect(res.body[0]).toHaveProperty('title');
+    expect(res.body[0]).toHaveProperty('createdAt');
+    expect(res.body[0]).toHaveProperty('updatedAt');
+
+    expect(res.body[0].id).toBe(playlists[0].id);
+    expect(res.body[0].title).toBe('Road Trip!');
+    expect(res.body[0].createdAt).toBe(playlists[0].created_at.toJSON());
+    expect(res.body[0].updatedAt).toBe(playlists[0].updated_at.toJSON());
+
+    expect(res.body[1].id).toBe(playlists[1].id);
+    expect(res.body[1].title).toBe('Love Mix Tape #341');
+    expect(res.body[1].createdAt).toBe(playlists[1].created_at.toJSON());
+    expect(res.body[1].updatedAt).toBe(playlists[1].updated_at.toJSON());
+
+    expect(res.body[2].id).toBe(playlists[2].id);
+    expect(res.body[2].title).toBe('All of the Yogas');
+    expect(res.body[2].createdAt).toBe(playlists[2].created_at.toJSON());
+    expect(res.body[2].updatedAt).toBe(playlists[2].updated_at.toJSON());
+  });
+
+  test('It should send back an empty array if there are no playlists', async () => {
+    const res = await request(app)
+      .get('/api/v1/playlists');
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toStrictEqual([]);
+  });
+});


### PR DESCRIPTION
Features of PR:

- Add tests for getting a list of all playlists with `GET /api/v1/playlists` endpoint. Includes test that an empty array is returned if no playlists are saved to the database.
- Add route for GET request to /api/v1/playlists to retrieve all playlists and return them in JSON format
- Add endpoint documentation to README
- Test coverage is at 93.64%

Refactors / Thoughts:

Right now the `createdAt` and `updatedAt` fields of the JSON response return strings, but we'll have to get rid of the quotes to match the project specs. I'll make a new ticket for this.