### PR TITLE
User can update a playlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,24 @@ The response will be a status `204` with no response body.
 
 #### 1) Getting a list of all playlists
 
-#### 2) Updating a playlist
+#### 2) Updating a playlist by ID
+
+A user can send a `PUT` request to `/api/v1/playlists/:id` to update the title of a playlist in the database by the playlist ID.
+
+The user's request body will contain the new title in the following format:
+```
+{ title: "Cheesy 80s Love Songs" }
+```
+
+The response body will be of the following format (displaying the updated title):
+```
+{
+  "id": 1,
+  "title": "Cheesy 80s Love Songs",
+  "createdAt": 2019-11-26T16:03:43+00:00,
+  "updatedAt": 2019-11-26T16:03:43+00:00,
+}
+```
 
 #### 3) Adding a playlist
 

--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -29,6 +29,40 @@ router.post('/', async (request, response) => {
   }
 });
 
+router.put('/:id', async (request, response) => {
+  let newTitle = request.body.title;
+
+  if (newTitle) {
+    let playlist = await database('playlists').where('id', request.params.id).first();
+    if (playlist) {
+      let updatedPlaylist = await database('playlists')
+        .where('id', playlist.id)
+        .update({title: newTitle}, ['id', 'title', 'created_at', 'updated_at']);
+
+      if (updatedPlaylist[0]) {
+        let updatedPlaylistFields = {
+          id: updatedPlaylist[0].id,
+          title: updatedPlaylist[0].title,
+          createdAt: updatedPlaylist[0].created_at,
+          updatedAt: updatedPlaylist[0].updated_at,
+        }
+        return response.status(200).json(updatedPlaylistFields);
+      } else {
+        let resp_obj = new ResponseObj(500, 'Unexpected error. Please try again.');
+        return errorResponse(res_obj, response);
+      }
+
+    } else {
+      let res_obj = new ResponseObj(404, 'No playlist with given ID was found. Please check the ID and try again.');
+      return errorResponse(res_obj, response);
+    }
+
+  } else {
+    let res_obj = new ResponseObj(400, 'Bad Request! Did you send a new playlist title?');
+    return errorResponse(res_obj, response);
+  }
+});
+
 router.delete('/:id', async (request, response) => {
   let rowsDeleted = await database('playlists').where('id', request.params.id).del();
 

--- a/tests/playlists/update-playlist.spec.js
+++ b/tests/playlists/update-playlist.spec.js
@@ -1,0 +1,73 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../../knexfile')[environment];
+const database = require('knex')(configuration);
+
+describe('Test update playlist endpoint', () => {
+  beforeEach(async () => {
+    await database.raw('truncate table playlists restart identity cascade');
+  });
+
+  afterEach(async () => {
+    await database.raw('truncate table playlists restart identity cascade');
+  });
+
+  test('It should update a playlist title by id', async () => {
+    let playlists = await database('playlists').insert([
+      { title: 'Lets go road trippin' },
+      { title: 'Sunday Funday' }
+    ], ['id', 'title', 'created_at', 'updated_at']);
+
+    const res = await request(app)
+      .put(`/api/v1/playlists/${playlists[0].id}`)
+      .send({ title: 'On the road again' })
+      .type('form');
+
+    expect(res.statusCode).toBe(200);
+
+    expect(res.body).toHaveProperty('id');
+    expect(res.body).toHaveProperty('title');
+    expect(res.body).toHaveProperty('createdAt');
+    expect(res.body).toHaveProperty('updatedAt');
+
+    expect(res.body.id).toBe(playlists[0].id);
+    expect(res.body.title).toBe('On the road again');
+    expect(res.body.title).not.toBe('Lets go road trippin');
+    expect(res.body.createdAt).toBe(playlists[0].created_at.toJSON());
+    expect(res.body.updatedAt).toBe(playlists[0].updated_at.toJSON());
+  });
+
+  test('It shows an error if missing the new title', async () => {
+    let playlists = await database('playlists').insert([
+      { title: 'Lets go road trippin' },
+      { title: 'Sunday Funday' }
+    ], ['id', 'title', 'created_at', 'updated_at']);
+
+    const res = await request(app)
+      .put(`/api/v1/playlists/${playlists[0].id}`)
+      .send({})
+      .type('form');
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toHaveProperty('status');
+    expect(res.body).toHaveProperty('errorMessage');
+    expect(res.body.status).toBe(400);
+    expect(res.body.errorMessage).toBe('Bad Request! Did you send a new playlist title?');
+  });
+
+  test('It shows an error if playlist with given ID is not found', async () => {
+    const res = await request(app)
+      .put('/api/v1/playlists/4')
+      .send({ title: 'Hooray for Mondays' })
+      .type('form');
+
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toHaveProperty('status');
+    expect(res.body).toHaveProperty('errorMessage');
+    expect(res.body.status).toBe(404);
+    expect(res.body.errorMessage).toBe('No playlist with given ID was found. Please check the ID and try again.');
+  });
+});


### PR DESCRIPTION
Features of PR:

- Add tests for updating a playlist with `PUT /api/v1/playlists/:id` endpoint. Includes tests for error handling with incorrect request body and unknown playlist id
- Add route for PUT request to `/api/v1/playlists/:id` to updating an existing playlist's title
- Add endpoint documentation to README
- Test coverage is at 94.55%

Refactors / Thoughts:

Same as the get all playlists endpoint, the `createdAt` and `updatedAt` fields of the JSON response return strings, but we'll have to get rid of the quotes to match the project specs.

I'd love your thoughts on refactoring the error handling of the route. It seems super long with all of the if/else statements, just because of the four different errors that could occur with the endpoint.