### PR TITLE
44 User can add a favorite to a playlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The following environment variables are required.
 
 #### 1) Getting a list of all favorite tracks
 
-When a user sends a `GET` request to `api/v1/favorites` it returns all favorited songs currently in the database.
+When a user sends a `GET` request to `/api/v1/favorites` it returns all favorited songs currently in the database.
 
 Response body will look like:
 ```
@@ -95,7 +95,7 @@ The response body will be:
 
 #### 4) Deleting a favorite track
 
-A user can send a `DELETE` request to `api/v1/favorites/:id` which deletes that favorite song from the database.
+A user can send a `DELETE` request to `/api/v1/favorites/:id` which deletes that favorite song from the database.
 
 The response will be a status `204` with no response body.
 
@@ -103,7 +103,7 @@ The response will be a status `204` with no response body.
 
 #### 1) Getting a list of all playlists
 
-When a user sends a `GET` request to `api/v1/playlists` it returns all playlists currently in the database.
+When a user sends a `GET` request to `/api/v1/playlists` it returns all playlists currently in the database.
 
 Response body will look like:
 ```
@@ -163,9 +163,23 @@ The response body will be:
 
 #### 4) Deleting a playlist
 
-A user can send a `DELETE` request to `api/v1/playlists/:id` which deletes that playlist from the database.
+A user can send a `DELETE` request to `/api/v1/playlists/:id` which deletes that playlist from the database.
 
 The response will be a status `204` with no response body.
+
+### Playlist Favorites Endpoint
+
+#### 1) Adding a favorite to a playlist
+
+A user can send a `POST` request to `/api/v1/playlists/:playlistID/favorites/:favoriteID` which adds the given favorite to the given playlist.
+
+The response body will be:
+
+```
+{
+  "Success": "{Song Title} has been added to {Playlist Title}!"
+}
+```
 
 ## Focus Areas
 

--- a/tests/favorites.spec.js
+++ b/tests/favorites.spec.js
@@ -1,9 +1,9 @@
 var shell = require('shelljs');
 var request = require("supertest");
-var app = require('../../app');
+var app = require('../app');
 
 const environment = process.env.NODE_ENV || 'test';
-const configuration = require('../../knexfile')[environment];
+const configuration = require('../knexfile')[environment];
 const database = require('knex')(configuration);
 
 describe('Favorites endpoints', () => {

--- a/tests/playlist.spec.js
+++ b/tests/playlist.spec.js
@@ -1,9 +1,9 @@
 var shell = require('shelljs');
 var request = require("supertest");
-var app = require('../../app');
+var app = require('../app');
 
 const environment = process.env.NODE_ENV || 'test';
-const configuration = require('../../knexfile')[environment];
+const configuration = require('../knexfile')[environment];
 const database = require('knex')(configuration);
 
 describe('Playlists endpoints', () => {

--- a/tests/playlistFavorites.spec.js
+++ b/tests/playlistFavorites.spec.js
@@ -1,0 +1,100 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../knexfile')[environment];
+const database = require('knex')(configuration);
+
+describe('Playlist favorites endpoints', () => {
+  beforeEach(async () => {
+    await database.raw('TRUNCATE TABLE playlists, favorites, "playlistFavorites" RESTART IDENTITY CASCADE');
+  });
+
+  afterEach(async () => {
+    await database.raw('TRUNCATE TABLE playlists, favorites, "playlistFavorites" RESTART IDENTITY CASCADE');
+  });
+
+  describe('Add playlist favorite endpoint', () => {
+    test('It can add a new playlist favorite', async () => {
+      let playlist_id = await database('playlists').insert({title: 'Jogging Jams'}, 'id');
+      let favorite_id = await database('favorites').insert({
+        title: 'Shake It Off',
+        artistName: 'T Swizzle',
+        genre: 'Poptastic',
+        rating: 1
+      }, 'id');
+
+      const res = await request(app)
+        .post(`/api/v1/playlists/${playlist_id[0]}/favorites/${favorite_id[0]}`);
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body).toHaveProperty('Success');
+      expect(res.body.Success).toEqual('Shake It Off has been added to Jogging Jams!');
+    });
+
+    test('It returns a 400 if favorite is already in playlist', async () => {
+      let playlist_id = await database('playlists').insert({title: 'Jogging Jams'}, 'id');
+      let favorite_id = await database('favorites').insert({
+        title: 'Shake It Off',
+        artistName: 'T Swizzle',
+        genre: 'Poptastic',
+        rating: 1
+      }, 'id');
+
+      await database('playlistFavorites')
+        .insert({favorite_id: favorite_id[0], playlist_id: playlist_id[0]})
+
+      const res = await request(app)
+        .post(`/api/v1/playlists/${playlist_id[0]}/favorites/${favorite_id[0]}`);
+
+      expect(res.statusCode).toBe(409)
+      expect(res.body).toHaveProperty('status')
+      expect(res.body).toHaveProperty('errorMessage')
+      expect(res.body.status).toEqual(409)
+      expect(res.body.errorMessage).toEqual('That favorite has already been added to that playlist!')
+    });
+
+    test('It returns a 404 if invalid favorite ID', async () => {
+      let playlist_id = await database('playlists').insert({title: 'Jogging Jams'}, 'id');
+
+      const res = await request(app)
+        .post(`/api/v1/playlists/${playlist_id[0]}/favorites/4`);
+
+      expect(res.statusCode).toBe(404)
+      expect(res.body).toHaveProperty('status')
+      expect(res.body).toHaveProperty('errorMessage')
+      expect(res.body.status).toEqual(404)
+      expect(res.body.errorMessage).toEqual('No favorite with given ID was found. Please check the ID and try again.')
+    });
+
+    test('It returns a 404 if invalid playlist ID', async () => {
+      let favorite_id = await database('favorites').insert({
+        title: 'Shake It Off',
+        artistName: 'T Swizzle',
+        genre: 'Poptastic',
+        rating: 1
+      }, 'id');
+
+      const res = await request(app)
+        .post(`/api/v1/playlists/5/favorites/${favorite_id[0]}`);
+
+      expect(res.statusCode).toBe(404)
+      expect(res.body).toHaveProperty('status')
+      expect(res.body).toHaveProperty('errorMessage')
+      expect(res.body.status).toEqual(404)
+      expect(res.body.errorMessage).toEqual('No playlist with given ID was found. Please check the ID and try again.')
+    });
+
+    test('It returns a 404 if invalid playlist ID', async () => {
+      const res = await request(app)
+        .post(`/api/v1/playlists/5/favorites/6`);
+
+      expect(res.statusCode).toBe(404)
+      expect(res.body).toHaveProperty('status')
+      expect(res.body).toHaveProperty('errorMessage')
+      expect(res.body.status).toEqual(404)
+      expect(res.body.errorMessage).toEqual('No playlist or favorite with given IDs were found. Please check the IDs and try again.')
+    });
+  });
+});


### PR DESCRIPTION
Features of PR:
- Add router method to add playlist to favorite by sending a `POST` request to `/api/v1/playlists/:id/favorites/:id`
- Add happy and sad path tests to add an existing favorite to an existing playlist
- Add documentation for endpoint

Testing:
- 91.95%

Thoughts/Refactors:
- Perhaps slimming down the error handling of the router itself. I think it's rather readable right now, but the length of the router function could be shortened