### PR TITLE
51 add timestamps and favorite uniqueness to playlistFavorites table

### DIFF
--- a/db/migrations/20200211161757_addTimestampsToPlaylistFavorites.js
+++ b/db/migrations/20200211161757_addTimestampsToPlaylistFavorites.js
@@ -1,0 +1,17 @@
+
+exports.up = function(knex) {
+  return Promise.all([
+    knex.schema.table('playlistFavorites', function(table) {
+      table.timestamps(true, true);
+    })
+  ]);
+};
+
+exports.down = function(knex) {
+  return Promise.all([
+    knex.schema.table('playlistFavorites', function(table) {
+      table.dropTimestamps('created_at');
+      table.dropTimestamps('updated_at');
+    })
+  ]);
+};

--- a/db/migrations/20200211162142_addUniquenessToPlaylistFavorites.js
+++ b/db/migrations/20200211162142_addUniquenessToPlaylistFavorites.js
@@ -1,0 +1,16 @@
+
+exports.up = function(knex) {
+  return Promise.all([
+    knex.schema.table('playlistFavorites', function(table) {
+      table.unique(['favorite_id', 'playlist_id']);
+    })
+  ]);
+};
+
+exports.down = function(knex) {
+  return Promise.all([
+    knex.schema.table('playlistFavorites', function(table) {
+      table.dropUnique(['favorite_id', 'playlist_id']);
+    })
+  ]);
+};


### PR DESCRIPTION
Features of PR:
- Add two migrations for the playlistFavorites table
  - One migration adds timestamps
  - One migration adds uniqueness so that a favorite track can't be added twice

Test Coverage:
- 91.95%