### PR TITLE
46 User Can Delete A Favorite From A Playlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,12 @@ The response body will be:
 }
 ```
 
+#### 4) Deleting a favorite from a playlist
+
+A user can send a `DELETE` request to `/api/v1/playlists/:playlistID/favorites/:favoriteID` which deletes that favorite song from the playlist (and the joins table of the database).
+
+The response will be a status `204` with no response body.
+
 ## Focus Areas
 
 - Creating an API

--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ The following environment variables are required.
 - **DATABASE_URL** set to the location of your production database
 - **MUSIXMATCH_API_KEY** set to your registered MusixMatch Developer API Key
 
+## Testing
+
+### Running Tests
+
+#### Run all tests
+
+One you have run a `npm install` you can run all test using the `npm test` command.
+
+#### Run individual tests
+
+Individual tests can be run using the `jest -t '<describeString> <itString>` command formula.
+
 ## How to Use / Endpoints
 
 ### Favorites Endpoint
@@ -207,18 +219,6 @@ The response will be a status `204` with no response body.
 ## Database
 
 DATABASE SCHEMA GOES HERE
-
-## Testing
-
-### Running Tests
-
-#### Run all tests
-
-One you have run a `npm install` you can run all test using the `npm test` command.
-
-#### Run individual tests
-
-Individual tests can be run using the `jest -t '<describeString> <itString>` command formula.
 
 ## Core Contributors
 - Brian Bower

--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -122,6 +122,29 @@ router.post('/:playlistID/favorites/:favoriteID', async (request, response) => {
   }
 });
 
+
+router.delete('/:playlistID/favorites/:favoriteID', async (request, response) => {
+  let playlist = await database('playlists').where('id', request.params.playlistID).select();
+  if (playlist.length) {
+    let favorite = await database('favorites').where('id', request.params.favoriteID).select();
+    if (favorite.length) {
+      let rowsDeleted = await database('playlistFavorites').where({playlist_id: request.params.playlistID, favorite_id: request.params.favoriteID}).del();
+      if (rowsDeleted === 1) {
+        return response.status(204).send();
+      } else {
+        let res_obj = new ResponseObj(404, 'No playlist favorite was found. Please check the ID and try again.');
+        return errorResponse(res_obj, response);
+      }
+    } else {
+      let res_obj = new ResponseObj(404, 'No favorite with given ID was found. Please check the ID and try again.');
+      return errorResponse(res_obj, response);
+    }
+  } else {
+    let res_obj = new ResponseObj(404, 'No playlist with given ID was found. Please check the ID and try again.');
+    return errorResponse(res_obj, response);
+  }
+});
+
 async function alreadyPlaylistFavorite(playlist, favorite) {
   let playlistFavorite = await database('playlistFavorites')
     .where({playlist_id: playlist.id, favorite_id: favorite.id});


### PR DESCRIPTION
Features of PR:
- Add tests for deleting a favorite from a playlist
  - Happy and sad paths accounted for
- Add the route to delete a favorite from a playlist with sad paths
- Documentation for `/api/v1/playlists/:playlistID/favorites/:favoritesID` endpoint
- Move the test section to directly after the setup section in the documentation

Test Coverage:
- 92.64%

Thoughts:
- As mentioned in slack: At first I just checked the joins table for the existence of a row with the passed in IDs but I felt that was unsatisfying. So I added checks to make sure the playlist exists and if so check if the favorite exists and then check the joins table. It is verbose but it just seems better.