### PR TITLE
47 Refactor GET /api/v1/playlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,23 +115,44 @@ The response will be a status `204` with no response body.
 
 #### 1) Getting a list of all playlists
 
-When a user sends a `GET` request to `/api/v1/playlists` it returns all playlists currently in the database.
+When a user sends a `GET` request to `/api/v1/playlists` it returns all playlists currently in the database. It also returns each playlist's song count, average song rating, and a list of favorite tracks that the playlist contains.
 
-Response body will look like:
+The response body will look like:
 ```
 [
- {
+  {
     "id": 1,
     "title": "Cleaning House",
+    "songCount": 2,
+    "songAvgRating": 27.5,
+    "favorites": [
+                    {
+                      "id": 1,
+                      "title": "We Will Rock You",
+                      "artistName": "Queen"
+                      "genre": "Rock",
+                      "rating": 25
+                    },
+                    {
+                      "id": 4,
+                      "title": "Back In Black",
+                      "artistName": "AC/DC"
+                      "genre": "Rock",
+                      "rating": 30
+                    }
+                  ],
     "createdAt": 2019-11-26T16:03:43+00:00,
     "updatedAt": 2019-11-26T16:03:43+00:00
   },
   {
     "id": 2,
     "title": "Running Mix",
+    "songCount": 0,
+    "songAvgRating": 0,
+    "favorites": []
     "createdAt": 2019-11-26T16:03:43+00:00,
     "updatedAt": 2019-11-26T16:03:43+00:00
-  },
+  }
 ]
 ```
 

--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -199,6 +199,14 @@ async function getFavorites(playlists) {
   return playlists.map(async (playlist) => {
     return await database('favorites').join('playlistFavorites', 'playlistFavorites.favorite_id', 'favorites.id').where('playlistFavorites.playlist_id', playlist.id);
   });
+function songAvgRating(favorites) {
+  let count = favorites.length;
+  if (count === 0) { return 0 }
+
+  let sum = 0;
+  favorites.forEach(favorite => sum += favorite.rating)
+
+  return sum / count;
 };
 
 

--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -34,19 +34,20 @@ router.get('/', async (request, response) => {
 
   if (playlists) {
     let favorites = await getFavorites(playlists);
-    console.log(favorites);
 
     let playlistsArray =  playlists.map((playlist, index) => {
       return {
         id: playlist.id,
         title: playlist.title,
+        songCount: favorites[index].length,
+        songAvgRating: songAvgRating(favorites[index]),
         favorites: favorites[index],
         createdAt: playlist.created_at,
         updatedAt: playlist.updated_at
       };
     });
 
-    Promise.all(playlistsArray).then(() => response.status(200).json(playlistsArray));
+    return response.status(200).json(playlistsArray);
   } else {
     let resp_obj = new ResponseObj(500, 'Unexpected error. Please try again.');
     return errorResponse(res_obj, response);

--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -196,9 +196,16 @@ async function addPlaylistToDB(playlist) {
 };
 
 async function getFavorites(playlists) {
-  return playlists.map(async (playlist) => {
-    return await database('favorites').join('playlistFavorites', 'playlistFavorites.favorite_id', 'favorites.id').where('playlistFavorites.playlist_id', playlist.id);
-  });
+  return Promise.all(
+    playlists.map(async (playlist) => {
+    return await database('favorites')
+      .join('playlistFavorites', 'playlistFavorites.favorite_id', 'favorites.id')
+      .where('playlistFavorites.playlist_id', playlist.id)
+      .select('favorites.id', 'favorites.title', 'favorites.artistName', 'favorites.genre', 'favorites.rating');
+    })
+  );
+};
+
 function songAvgRating(favorites) {
   let count = favorites.length;
   if (count === 0) { return 0 }

--- a/tests/playlists.spec.js
+++ b/tests/playlists.spec.js
@@ -219,7 +219,7 @@ describe('Playlists endpoints', () => {
       expect(res.body[0].favorites[0]).toHaveProperty('artistName');
       expect(res.body[0].favorites[0]).toHaveProperty('genre');
       expect(res.body[0].favorites[0]).toHaveProperty('rating');
-      expect(res.body[0].favorites.count).toBe(2);
+      expect(res.body[0].favorites.length).toBe(2);
       expect(res.body[0].createdAt).toBe(playlists[0].created_at.toJSON());
       expect(res.body[0].updatedAt).toBe(playlists[0].updated_at.toJSON());
 
@@ -232,7 +232,7 @@ describe('Playlists endpoints', () => {
       expect(res.body[1].favorites[0]).toHaveProperty('artistName');
       expect(res.body[1].favorites[0]).toHaveProperty('genre');
       expect(res.body[1].favorites[0]).toHaveProperty('rating');
-      expect(res.body[1].favorites.count).toBe(1);
+      expect(res.body[1].favorites.length).toBe(1);
       expect(res.body[1].createdAt).toBe(playlists[1].created_at.toJSON());
       expect(res.body[1].updatedAt).toBe(playlists[1].updated_at.toJSON());
 
@@ -240,7 +240,7 @@ describe('Playlists endpoints', () => {
       expect(res.body[2].title).toBe('All of the Yogas');
       expect(res.body[2].songCount).toBe(0);
       expect(res.body[2].songAvgRating).toBe(0);
-      expect(res.body[2].favorites).toBe([]);
+      expect(res.body[2].favorites).toStrictEqual([]);
       expect(res.body[2].createdAt).toBe(playlists[2].created_at.toJSON());
       expect(res.body[2].updatedAt).toBe(playlists[2].updated_at.toJSON());
     });

--- a/tests/playlists.spec.js
+++ b/tests/playlists.spec.js
@@ -8,11 +8,11 @@ const database = require('knex')(configuration);
 
 describe('Playlists endpoints', () => {
   beforeEach(async () => {
-    await database.raw('TRUNCATE TABLE playlists RESTART IDENTITY CASCADE');
+    await database.raw('TRUNCATE TABLE playlists, favorites, "playlistFavorites" RESTART IDENTITY CASCADE');
   });
 
   afterEach(async () => {
-    await database.raw('TRUNCATE TABLE playlists RESTART IDENTITY CASCADE');
+    await database.raw('TRUNCATE TABLE playlists, favorites, "playlistFavorites" RESTART IDENTITY CASCADE');
   });
 
   describe('Add playlists endpoint', () => {
@@ -166,6 +166,36 @@ describe('Playlists endpoints', () => {
         { title: 'All of the Yogas' }
       ], ['id', 'created_at', 'updated_at']);
 
+      let favorites = await database('favorites').returning('*').insert([
+        {
+          title: 'Banana Pancakes',
+          artistName: 'Jack Johnson',
+          genre: 'Rock',
+          rating: 26
+        },
+        {
+          title: 'Blank Space',
+          artistName: 'Taylor Swift',
+          genre: 'Pop',
+          rating: 84
+        }
+      ]);
+
+      let playlistFavorites = await database('playlistFavorites').returning('*').insert([
+        {
+          playlist_id: playlists[0].id,
+          favorite_id: favorites[0].id
+        },
+        {
+          playlist_id: playlists[0].id,
+          favorite_id: favorites[1].id
+        },
+        {
+          playlist_id: playlists[1].id,
+          favorite_id: favorites[0].id
+        },
+      ]);
+
       const res = await request(app)
         .get('/api/v1/playlists');
 
@@ -174,21 +204,43 @@ describe('Playlists endpoints', () => {
 
       expect(res.body[0]).toHaveProperty('id');
       expect(res.body[0]).toHaveProperty('title');
+      expect(res.body[0]).toHaveProperty('songCount');
+      expect(res.body[0]).toHaveProperty('songAvgRating');
+      expect(res.body[0]).toHaveProperty('favorites');
       expect(res.body[0]).toHaveProperty('createdAt');
       expect(res.body[0]).toHaveProperty('updatedAt');
 
       expect(res.body[0].id).toBe(playlists[0].id);
       expect(res.body[0].title).toBe('Road Trip!');
+      expect(res.body[0].songCount).toBe(2);
+      expect(res.body[0].songAvgRating).toBe(55);
+      expect(res.body[0].favorites[0]).toHaveProperty('id');
+      expect(res.body[0].favorites[0]).toHaveProperty('title');
+      expect(res.body[0].favorites[0]).toHaveProperty('artistName');
+      expect(res.body[0].favorites[0]).toHaveProperty('genre');
+      expect(res.body[0].favorites[0]).toHaveProperty('rating');
+      expect(res.body[0].favorites.count).toBe(2);
       expect(res.body[0].createdAt).toBe(playlists[0].created_at.toJSON());
       expect(res.body[0].updatedAt).toBe(playlists[0].updated_at.toJSON());
 
       expect(res.body[1].id).toBe(playlists[1].id);
       expect(res.body[1].title).toBe('Love Mix Tape #341');
+      expect(res.body[1].songCount).toBe(1);
+      expect(res.body[1].songAvgRating).toBe(26);
+      expect(res.body[1].favorites[0]).toHaveProperty('id');
+      expect(res.body[1].favorites[0]).toHaveProperty('title');
+      expect(res.body[1].favorites[0]).toHaveProperty('artistName');
+      expect(res.body[1].favorites[0]).toHaveProperty('genre');
+      expect(res.body[1].favorites[0]).toHaveProperty('rating');
+      expect(res.body[1].favorites.count).toBe(1);
       expect(res.body[1].createdAt).toBe(playlists[1].created_at.toJSON());
       expect(res.body[1].updatedAt).toBe(playlists[1].updated_at.toJSON());
 
       expect(res.body[2].id).toBe(playlists[2].id);
       expect(res.body[2].title).toBe('All of the Yogas');
+      expect(res.body[2].songCount).toBe(0);
+      expect(res.body[2].songAvgRating).toBe(0);
+      expect(res.body[2].favorites).toBe([]);
       expect(res.body[2].createdAt).toBe(playlists[2].created_at.toJSON());
       expect(res.body[2].updatedAt).toBe(playlists[2].updated_at.toJSON());
     });


### PR DESCRIPTION
Features of PR:
- Refactor `GET` route to `/api/v1/playlists` to add songCount, songAvgRating, and favorites attributes to response body
- Modify existing tests to account for added attributes to response body

Testing:
- 93.06%

Thoughts/Refactors:
- Eventually we may want to refactor the getFavorites method to use Objection.js, which would avoid the n+1 queries via eager loading