### PR TITLE
57 Cascade Delete (Delete from the Joins Table)

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ The response will be a status `204` with no response body.
 
 ## Database
 
-DATABASE SCHEMA GOES HERE
+![schema diagram](https://user-images.githubusercontent.com/38663414/74381281-0b41d480-4de3-11ea-80fd-711ae471cf83.png)
 
 ## Core Contributors
 - Brian Bower

--- a/routes/api/v1/favorites.js
+++ b/routes/api/v1/favorites.js
@@ -75,6 +75,7 @@ router.get('/:id', async (request, response) => {
 });
 
 router.delete('/:id', async (request, response) => {
+  await database('playlistFavorites').where('favorite_id', request.params.id).del();
   let rowsDeleted = await database('favorites').where('id', request.params.id).del();
 
   if (rowsDeleted === 1) {

--- a/routes/api/v1/playlists.js
+++ b/routes/api/v1/playlists.js
@@ -89,6 +89,7 @@ router.put('/:id', async (request, response) => {
 });
 
 router.delete('/:id', async (request, response) => {
+  await database('playlistFavorites').where('playlist_id', request.params.id).del();
   let rowsDeleted = await database('playlists').where('id', request.params.id).del();
 
   if (rowsDeleted === 1) {


### PR DESCRIPTION
Features of PR:
- Add tests to check that when a playlist or favorite is deleted then the playlistFavorites related to that resource are also deleted.
- Add deletions to the `DELETE` favorites and playlists to remove their related resources from the joins table when one of those resources is deleted.

Test Coverage:
- 93.01%